### PR TITLE
fix: enable explicit types in the parser interface

### DIFF
--- a/src/main/kotlin/data/database/AuditLogCsvParser.kt
+++ b/src/main/kotlin/data/database/AuditLogCsvParser.kt
@@ -2,12 +2,13 @@ package data.database
 
 import data.dto.LogEntityDto
 
-class AuditLogCsvParser : Parser {
-    override fun <T> write(entity: T) {
+class AuditLogCsvParser : Parser<LogEntityDto> {
+
+    override fun write(entity: LogEntityDto) {
         TODO("Not yet implemented")
     }
 
-    override fun <T> read(): T {
+    override fun read(): LogEntityDto {
         TODO("Not yet implemented")
     }
 

--- a/src/main/kotlin/data/database/Parser.kt
+++ b/src/main/kotlin/data/database/Parser.kt
@@ -1,8 +1,8 @@
 package data.database
 
-interface Parser {
+interface Parser<DTO> {
 
-    fun <T> write(entity: T)
-    fun <T> read(): T
+    fun write(entity: DTO)
+    fun read(): DTO
 
 }

--- a/src/main/kotlin/data/database/ProjectsCsvParser.kt
+++ b/src/main/kotlin/data/database/ProjectsCsvParser.kt
@@ -2,14 +2,14 @@ package data.database
 
 import data.dto.ProjectDto
 
-class ProjectsCsvParser : Parser {
-    override fun <T> write(entity: T) {
+class ProjectsCsvParser : Parser<ProjectDto> {
+
+    override fun write(entity: ProjectDto) {
         TODO("Not yet implemented")
     }
 
-    override fun <T> read(): T {
+    override fun read(): ProjectDto {
         TODO("Not yet implemented")
     }
-
 
 }

--- a/src/main/kotlin/data/database/StatesCsvParser.kt
+++ b/src/main/kotlin/data/database/StatesCsvParser.kt
@@ -1,13 +1,15 @@
 package data.database
 
-class StatesCsvParser : Parser {
-    override fun <T> write(entity: T) {
+import data.dto.StateDto
+
+class StatesCsvParser : Parser<StateDto> {
+
+    override fun write(entity: StateDto) {
         TODO("Not yet implemented")
     }
 
-    override fun <T> read(): T {
+    override fun read(): StateDto {
         TODO("Not yet implemented")
     }
-
 
 }

--- a/src/main/kotlin/data/database/TasksCsvParser.kt
+++ b/src/main/kotlin/data/database/TasksCsvParser.kt
@@ -1,13 +1,14 @@
 package data.database
 
-class TasksCsvParser : Parser {
+import data.dto.TaskDto
 
-    override fun <T> write(entity: T) {
+class TasksCsvParser : Parser<TaskDto> {
+
+    override fun read(): TaskDto {
         TODO("Not yet implemented")
     }
 
-    override fun <T> read(): T {
+    override fun write(entity: TaskDto) {
         TODO("Not yet implemented")
     }
-
 }

--- a/src/main/kotlin/data/database/UsersCsvParser.kt
+++ b/src/main/kotlin/data/database/UsersCsvParser.kt
@@ -2,13 +2,13 @@ package data.database
 
 import data.dto.UserDto
 
-class UsersCsvParser : Parser {
-    override fun <T> write(entity: T) {
+class UsersCsvParser : Parser<UserDto> {
+
+    override fun write(entity: UserDto) {
         TODO("Not yet implemented")
     }
 
-    override fun <T> read(): T {
+    override fun read(): UserDto {
         TODO("Not yet implemented")
     }
-
 }


### PR DESCRIPTION
the issue was when you use the parser interface there is no restriction to what DTO you can parse , so i refactored the parser interface to be generic to restrict parsing a specific DTO.